### PR TITLE
Header passthru

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -46,7 +46,7 @@ type Handler struct {
 	// port     string // port on which chain with forwardproxy is listening on
 	Hosts caddyhttp.MatchHost `json:"hosts,omitempty"`
 
-	ProbeResistance *ProbeResistance
+	ProbeResistance *ProbeResistance `json:"probe_resistance"`
 
 	DialTimeout caddy.Duration `json:"dial_timeout,omitempty"` // for initial tcp connection
 

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -164,6 +164,10 @@ func (c *HTTPConnectDialer) DialContext(ctx context.Context, network, address st
 			rawConn.Close()
 			return nil, errors.New("Proxy responded with non 200 code: " + resp.Status)
 		}
+		padding := resp.Header.Get("Padding")
+		if padding != "" {
+			return rawConn, errors.New("Padding: " + padding)
+		}
 		return rawConn, nil
 	}
 


### PR DESCRIPTION
@darhwa Have a look this too. With only this can the header passing be tested.

To build (golang needs a regular http proxy), following https://github.com/caddyserver/xcaddy#custom-builds:
```
xcaddy build --with github.com/klzgrad/forwardproxy@passthru
sudo setcap cap_net_bind_service=+ep ./caddy
```

caddy.json:
```
{
  "admin": {"disabled": true},
  "logging": {"sink": {"writer": {"output": "discard"}}},
  "apps": {
    "http": {
      "servers": {
        "srv0": {
          "listen": [":443"],
          "routes": [{
            "handle": [{
              "handler": "forward_proxy",
              "auth_user": "user",
              "auth_pass": "pass",
              "upstream": "http://127.0.0.1:8080",
              "probe_resistance": {"domain": "secret.localhost"}
            }]
          }, {
            "match": [{"host": ["example.com"]}],
            "handle": [{
              "handler": "file_server",
              "root": "/var/www/html"
            }],
            "terminal": true
          }],
          "tls_connection_policies": [{
            "match": {"sni": ["example.com"]},
            "certificate_selection": {"any_tag": ["cert0"]}
          }]
        }
      }
    },
    "tls": {
      "certificates": {
        "load_files": [{
          "certificate": "example.com.crt",
          "key": "example.com.key",
          "tags": ["cert0"]
        }]
      }
    }
  }
}
```
The certificates are copied from live Caddy's Let's Encrypt ones. But to make it work in localhost have to block ocsp.int-x3.letsencrypt.org in /etc/hosts.

To run
```
./caddy run --config caddy.json
```