### PR TITLE
README: Adapt documentation for current forwardproxy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Linux 64bit binaries are at <https://github.com/klzgrad/forwardproxy/releases>
 4. Build caddy with forwardproxy: `xcaddy build --with github.com/caddyserver/forwardproxy@caddy2=$PWD`
 5. Result is a `caddy` executable that you can e.g. directly start with `sudo ./caddy run` (create your `Caddyfile` in the same directory)
 
+### Running as daemon
+
+Manually install Caddy as a service on Linux with these instructions: [Systemd unit example](https://github.com/klzgrad/naiveproxy/wiki/Run-Caddy-as-a-daemon)
+
 ## Client Configuration
 
 Please be aware that client support varies widely, and there are edge cases where clients may not use the proxy when it should or could. It's up to you to be aware of these limitations.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Secure forward proxy plugin for the Caddy web server
 
-[![Build Status](https://travis-ci.org/caddyserver/forwardproxy.svg?branch=master)](https://travis-ci.org/caddyserver/forwardproxy)  
-[![Join the chat at https://gitter.im/forwardproxy/Lobby](https://badges.gitter.im/forwardproxy/Lobby.svg)](https://gitter.im/forwardproxy/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-
 This plugin enables [Caddy](https://caddyserver.com) to act as a forward proxy, with support for HTTP/2.0 and HTTP/1.1 requests. HTTP/2.0 will usually improve performance due to multiplexing.
 
 Forward proxy plugin includes common features like Access Control Lists and authentication, as well as some unique features to assist with security and privacy. Default configuration of forward proxy is compliant with existing HTTP standards, but some features force plugin to exhibit non-standard but non-breaking behavior to preserve privacy.
@@ -16,38 +12,29 @@ For a complete list of features and their usage, see Caddyfile syntax:
 
 The simplest way to enable the forward proxy without authentication just include the `forward_proxy` directive in your Caddyfile. However, this allows anyone to use your server as a proxy, which might not be desirable.
 
-The `forward_proxy` directive has no default order and must be used within a `route` directive to explicitly specify its order of evaluation. In the Caddyfile the addresses must start with `:443` for the `forward_proxy` to work for proxy requests of all origins.
+Using the `order` directive you must give the order in which `forward_proxy` and other directives should be used.
 
-Here's an example of all properties in use (note that the syntax is subject to change):
+In the Caddyfile the addresses must start with `:443` for the `forward_proxy` to work for proxy requests of all origins.
+
+Simple example that uses forward_proxy as first priority and as second just shows a webpage (using `file_server` directive) to hide that this is a proxy:
 
 ```
-:443, example.com
-route {
+{
+  order forward_proxy before file_server
+}
+:443, example.com {
+  tls acme@example.com
   forward_proxy {
-    basic_auth user1 0NtCL2JPJBgPPMmlPcJ
-    basic_auth user2 密码
-    ports     80 443
+    basic_auth abc def
     hide_ip
     hide_via
-    probe_resistance secret-link-kWWL9Q.com # alternatively you can use a real domain, such as caddyserver.com
-    serve_pac        /secret-proxy.pac
-    dial_timeout     30
-    upstream         https://user:password@extra-upstream-hop.com
-    acl {
-      allow     *.caddyserver.com
-      deny      192.168.1.1/32 192.168.0.0/16 *.prohibitedsite.com *.localhost
-      allow     ::1/128 8.8.8.8 github.com *.github.io
-      allow_file /path/to/whitelist.txt
-      deny_file  /path/to/blacklist.txt
-      allow     all
-      deny      all # unreachable rule, remaining requests are matched by `allow all` above
-    }
+    probe_resistance
   }
-  file_server
+  file_server {
+    root /home/user/webpage
+  }
 }
 ```
-
-(The square brackets `[ ]` indicate values you should replace; do not actually include the brackets.)
 
 ##### Security
 
@@ -141,17 +128,19 @@ Supported schemes to localhost: socks5, http, https (certificate check is ignore
 _Default: no upstream proxy._
 
 ## Get forwardproxy
+
 #### Download prebuilt binary
-Binaries are at https://caddyserver.com/download  
-Don't forget to add `http.forwardproxy` plugin.
+
+Linux 64bit binaries are at <https://github.com/klzgrad/forwardproxy/releases>
 
 #### Build from source
 
-0. Install latest Golang 1.12 or above and set export GO111MODULE=on
-1. ```bash
-   go install github.com/caddyserver/forwardproxy/cmd/caddy
-   ```   
-   Built `caddy` binary will be stored in $GOPATH/bin.  
+0. Install Golang 1.14 or above and the `git` client
+1. Checkout repository: `git checkout https://github.com/klzgrad/forwardproxy.git`
+2. Change into directory: `cd forwardproxy`
+3. Install caddyservers xcaddy: `go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest`
+4. Build caddy with forwardproxy: `xcaddy build --with github.com/caddyserver/forwardproxy@caddy2=$PWD`
+5. Result is a `caddy` executable that you can e.g. directly start with `sudo ./caddy run` (create your `Caddyfile` in the same directory)
 
 ## Client Configuration
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Simple example that uses forward_proxy as first priority and as second just show
 }
 ```
 
-##### Security
+### Security
 
 - **basic_auth [user] [password]**  
 Sets basic HTTP auth credentials. This property may be repeated multiple times. Note that this is different from Caddy's built-in `basic_auth` directive. BE SURE TO CHECK THE NAME OF THE SITE THAT IS REQUESTING CREDENTIALS BEFORE YOU ENTER THEM.  
@@ -55,7 +55,7 @@ Make sure that specified domain name is visitable, does not contain uppercase ch
 Only this address will trigger a 407 response, prompting browsers to request credentials from user and cache them for the rest of the session.
 _Default: no probing resistance._
 
-##### Privacy
+### Privacy
 
 - **hide_ip**  
 If set, forwardproxy will not add user's IP to "Forwarded:" header.  
@@ -67,7 +67,7 @@ If set, forwardproxy will not add Via header, and prevents simple way to detect 
 WARNING: there are other side-channels to determine this.  
 _Default: no hiding; Header in form of `Via: 2.0 caddy` will be sent out._
 
-##### Access Control
+### Access Control
 
 - **ports [integer] [integer]...**  
 Specifies ports forwardproxy will whitelist for all requests. Other ports will be forbidden.  
@@ -107,13 +107,13 @@ acl {
 }  
 _Default deny rules intend to prohibit access to localhost and local networks and may be expanded in future._
 
-##### Timeouts
+### Timeouts
 
 - **dial_timeout [integer]**  
 Sets timeout (in seconds) for establishing TCP connection to target website. Affects all requests.  
 _Default: 20 seconds._
 
-##### Other
+### Other
 
 - **serve_pac [/path.pac]**  
 Generate (in-memory) and serve a [Proxy Auto-Config](https://en.wikipedia.org/wiki/Proxy_auto-config) file on given path. If no path is provided, the PAC file will be served at `/proxy.pac`. NOTE: If you enable probe_resistance, your PAC file should also be served at a secret location; serving it at a predictable path can easily defeat probe resistance.  
@@ -129,11 +129,11 @@ _Default: no upstream proxy._
 
 ## Get forwardproxy
 
-#### Download prebuilt binary
+### Download prebuilt binary
 
 Linux 64bit binaries are at <https://github.com/klzgrad/forwardproxy/releases>
 
-#### Build from source
+### Build from source
 
 0. Install Golang 1.14 or above and the `git` client
 1. Checkout repository: `git checkout https://github.com/klzgrad/forwardproxy.git`

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Linux 64bit binaries are at <https://github.com/klzgrad/forwardproxy/releases>
 4. Build caddy with forwardproxy: `xcaddy build --with github.com/caddyserver/forwardproxy@caddy2=$PWD`
 5. Result is a `caddy` executable that you can e.g. directly start with `sudo ./caddy run` (create your `Caddyfile` in the same directory)
 
-### Running as daemon
+### Run as daemon
 
 Manually install Caddy as a service on Linux with these instructions: [Systemd unit example](https://github.com/klzgrad/naiveproxy/wiki/Run-Caddy-as-a-daemon)
 


### PR DESCRIPTION
Make some changes to README.md to remove some obsolete links, give an working Caddyfile example and instruction where to download current version or build from scratch.